### PR TITLE
Sitemap and dropdown

### DIFF
--- a/js/simple-301-redirects.js
+++ b/js/simple-301-redirects.js
@@ -3,7 +3,7 @@ jQuery(document).ready(function($) {
 	// turn delete column into edit/delete actions
 	$('.s301r-delete-head').addClass('s301r-actions-head').removeClass('s301r-delete-head').text('Actions');
 	$('.s301r-delete').html('<!--<a href="#" class="s301r-edit-link">Edit</a>&nbsp;--><a href="#" class="s301r-delete-link">Delete</a>');
-	
+
 	// ajax delete
 	$('.s301r-delete-link').click(function(){
 		var confirm_delete = confirm('Are you sure you want to delete this redirect?');
@@ -30,6 +30,12 @@ jQuery(document).ready(function($) {
 		return false;
 	});
 
+	$('.s301r_set_redirect').change(function(e) {
+		var redirect = $(this).val(),
+			textboxName = (typeof $(this).data('index') === 'number') ? '301_redirects[update_destintation]['+$(this).data('index')+']' : '301_redirects[destination]';
+		$('input[name="'+textboxName+'"]').val(redirect);
+	});
+
 	// edit link
 	$('.s301r-edit-link').click(function(){
 		// swap text for inputs
@@ -50,4 +56,3 @@ jQuery(document).ready(function($) {
 		return false;
 	});
 });
-

--- a/wp-simple-301-redirects.php
+++ b/wp-simple-301-redirects.php
@@ -185,7 +185,7 @@ if (!class_exists("Simple301redirects")) {
 					<tr id="s301r_row_'.$index.'" class="'.$row_class.'">
 						<td class="s301r_request">'.$redirect['request'].'</td>
 						<td>&raquo;</td>
-						<td class="s301r_destination">'.$redirect['destination'].'</td>
+						<td class="s301r_destination"><input name="301_redirects[update_destintation]['.$index.']" value="'.$redirect['destination'].'" style="width:80%" /></td>
 						<td class="s301r-delete"><input type="checkbox" name="301_redirects[delete][]" value="'.$index.'"></td>
 					</tr>
 
@@ -210,8 +210,7 @@ if (!class_exists("Simple301redirects")) {
 			$redirects = get_option( 's301r_redirects' );
 			if ($redirects == '') { $redirects = array(); }
 
-			//insert sitemap data
-			if ( ($_FILES['sitemap']) ) {
+			if ( $_FILES['sitemap']['size'] ) {
 				$urls = $this->process_sitemap($_FILES['sitemap']);
 				foreach ($urls as $url) {
 					$redirects[] = $this->create_redirect($url, '');
@@ -219,6 +218,12 @@ if (!class_exists("Simple301redirects")) {
 			}
 
 			$data = $_POST['301_redirects'];
+
+			if ( isset($data['update_destintation']) ) {
+				foreach ( $data['update_destintation'] as $index => $destination ) {
+					$redirects[$index]['destination'] = trim($destination);
+				}
+			}
 
 			// delete checked redirect
 			if (isset($data['delete']) && is_array($data['delete'])) {

--- a/wp-simple-301-redirects.php
+++ b/wp-simple-301-redirects.php
@@ -331,9 +331,11 @@ if (!class_exists("Simple301redirects")) {
 				return;
 			}
 			try {
-				$xml = simplexml_load_file($file['tmp_name']);
+				$dom = new DOMDocument;
+				$dom->loadXML( file_get_contents( $file['tmp_name'] ) );
+				$locs = $dom->getElementsByTagName('loc');
 			} catch (Exception $e) {
-				$this->messages_add( __('XML parser not installed or file could not be parsed'), 'error');
+				$this->messages_add( __('XML parser not installed or file is not a sitemap'), 'error');
 				return;
 			}
 
@@ -341,10 +343,10 @@ if (!class_exists("Simple301redirects")) {
 			$redirects = get_option( 's301r_redirects' );
 			if ($redirects == '') { $redirects = array(); }
 
-			foreach ($xml->url as $url_obj) {
-				$url_str = empty($url_obj->loc) ? '' : (string) $url_obj->loc;
-				if ( $url_str !== '' ) {
-					$redirect = $this->create_redirect($url_str, '');
+			foreach ($locs as $loc) {
+				$url = (string) $loc->nodeValue;
+				if ( $url !== '' ) {
+					$redirect = $this->create_redirect($url, '');
 					array_push( $redirects, $redirect );
 				}
 			}

--- a/wp-simple-301-redirects.php
+++ b/wp-simple-301-redirects.php
@@ -76,13 +76,13 @@ if (!class_exists("Simple301redirects")) {
 		?>
 		<div class="wrap simple_301_redirects">
 
-		<?php
-			if (isset($_POST['301_redirects'])) {
-				echo '<div id="message" class="updated"><p>Settings saved</p></div>';
-			}
-		?>
+		<h2>Simple 301 Redirects</h2>
 
-			<h2>Simple 301 Redirects</h2>
+			<?php
+				if (isset($_POST['301_redirects'])) {
+					echo '<div id="message" class="updated"><p>Settings saved</p></div>';
+				}
+			?>
 
 			<form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
 				<input type="hidden" name="cmd" value="_s-xclick">
@@ -132,6 +132,7 @@ if (!class_exists("Simple301redirects")) {
 
 			</form>
 
+			<hr />
 			<div class="documentation">
 				<h2>Documentation</h2>
 				<h3>Basic Redirects</h3>

--- a/wp-simple-301-redirects.php
+++ b/wp-simple-301-redirects.php
@@ -31,12 +31,12 @@ License: GPLv3
 //@todo: notify the bulk upload author that you'll be updating the storage format. maybe even patch his plugin for him. https://wordpress.org/plugins/simple-301-redirects-addon-bulk-uploader/
 
 if (!class_exists("Simple301redirects")) {
-	
+
 	class Simple301Redirects {
 
 		function initialize_admin() {
 			$this->maybe_upgrade_db(); // upgrade the storage format if needed
-			
+
 			// load necessary js
 			wp_register_script( 's301r-script', plugins_url( '/js/simple-301-redirects.js', __FILE__ ), array('jquery') );
 			add_action('admin_enqueue_scripts', array($this,'write_scripts'));
@@ -47,15 +47,15 @@ if (!class_exists("Simple301redirects")) {
 
 		function write_scripts() {
 			wp_enqueue_script( 's301r-script' );
-			
+
 			// make ajax_url available to the script
-			wp_localize_script( 's301r-script', 's301r_ajax', array( 
+			wp_localize_script( 's301r-script', 's301r_ajax', array(
 					'ajax_url' => admin_url( 'admin-ajax.php' ),
 					'delete_nonce' => wp_create_nonce( 'delete-redirect-nonce' ),
 				)
 			);
 		}
-		
+
 		/**
 		 * create_menu function
 		 * generate the link to the options page under settings
@@ -65,7 +65,7 @@ if (!class_exists("Simple301redirects")) {
 		function create_menu() {
 		  add_options_page('301 Redirects', '301 Redirects', 'manage_options', '301options', array($this,'options_page'));
 		}
-		
+
 		/**
 		 * options_page function
 		 * generate the options page in the wordpress admin
@@ -75,13 +75,13 @@ if (!class_exists("Simple301redirects")) {
 		function options_page() {
 		?>
 		<div class="wrap simple_301_redirects">
-		
+
 		<?php
 			if (isset($_POST['301_redirects'])) {
 				echo '<div id="message" class="updated"><p>Settings saved</p></div>';
 			}
 		?>
-		
+
 			<h2>Simple 301 Redirects</h2>
 
 			<form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
@@ -93,36 +93,43 @@ if (!class_exists("Simple301redirects")) {
 				</p>
 				<img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
 			</form>
-			
-			<form method="post" id="simple_301_redirects_form" action="options-general.php?page=301options">
-			
-			<?php wp_nonce_field( 'save_redirects', '_s301r_nonce' ); ?>
 
-			<table class="widefat">
-				<thead>
-					<tr>
-						<th colspan="2">Request <small>example:&nbsp;/about.htm</small></th>
-						<th>Destination <small>example:&nbsp;<?php echo get_option('home'); ?>/about/</small></th>
-						<th class="s301r-delete-head">Delete</th>
-					</tr>
-				</thead>
-				<tbody>
-					<?php echo $this->expand_redirects(); ?>
-					<tr>
-						<td style="width:35%;"><input type="text" name="301_redirects[request]" value="" style="width:99%;" /></td>
-						<td style="width:2%;">&raquo;</td>
-						<td><input type="text" name="301_redirects[destination]" value="" style="width:99%;" /></td>
-						<td style="width:4%;">&nbsp;</td>
-					</tr>
-				</tbody>
-			</table>
-			
-			<?php
-			$settings = get_option( 's301r_settings' );
-			$wildcard_checked = ($settings['wildcard'] === 'true') ? ' checked="checked"' : ''; ?>
-			<p><input type="checkbox" name="301_redirects[wildcard]" id="wps301-wildcard"<?php echo $wildcard_checked; ?> /><label for="wps301-wildcard"> Use Wildcards?</label></p>
-			
-			<p class="submit"><input type="submit" name="submit_s301r" class="button-primary" value="<?php _e('Save Changes') ?>" /></p>
+			<form method="post" id="simple_301_redirects_form" action="options-general.php?page=301options" enctype="multipart/form-data">
+
+				<?php wp_nonce_field( 'save_redirects', '_s301r_nonce' ); ?>
+
+				<table class="widefat">
+					<thead>
+						<tr>
+							<th colspan="2">Request <small>example:&nbsp;/about.htm</small></th>
+							<th>Destination <small>example:&nbsp;<?php echo get_option('home'); ?>/about/</small></th>
+							<th class="s301r-delete-head">Delete</th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php echo $this->expand_redirects(); ?>
+						<tr>
+							<td style="width:35%;"><input type="text" name="301_redirects[request]" value="" style="width:99%;" /></td>
+							<td style="width:2%;">&raquo;</td>
+							<td><input type="text" name="301_redirects[destination]" value="" style="width:99%;" /></td>
+							<td style="width:4%;">&nbsp;</td>
+						</tr>
+					</tbody>
+				</table>
+
+				<?php
+				$settings = get_option( 's301r_settings' );
+				$wildcard_checked = ($settings['wildcard'] === 'true') ? ' checked="checked"' : ''; ?>
+				<p><input type="checkbox" name="301_redirects[wildcard]" id="wps301-wildcard"<?php echo $wildcard_checked; ?> /><label for="wps301-wildcard"> Use Wildcards?</label></p>
+
+				<p class="submit"><input type="submit" name="submit_s301r" class="button-primary" value="<?php _e('Save Changes') ?>" /></p>
+
+				<hr />
+
+				<p><label for="sitemap"><strong>Input from Sitemap</strong></label></p>
+				<p><input type="file" id="sitemap" name="sitemap" /></p>
+				<p class="submit"><input type="submit" name="submit_s301r" class="button-primary" value="<?php _e('Upload') ?>" /></p>
+
 			</form>
 
 			<div class="documentation">
@@ -134,7 +141,7 @@ if (!class_exists("Simple301redirects")) {
 					<li><strong>Request:</strong> /old-page/</li>
 					<li><strong>Destination:</strong> /new-page/</li>
 				</ul>
-				
+
 				<h3>Wildcard Redirects</h3>
 				<p>Wildcard redirects can match more than one URL. They use an asterisk (*) to represent any characters. This is a powerful way to redirect an entire directory of pages with one line.</p>
 				<h4>Example</h4>
@@ -142,7 +149,7 @@ if (!class_exists("Simple301redirects")) {
 					<li><strong>Request:</strong> /old-folder/*</li>
 					<li><strong>Destination:</strong> /redirect-everything-here/</li>
 				</ul>
-		
+
 				<p>You can also use the asterisk in the destination to replace whatever it matched in the request if you like. Something like this:</p>
 				<h4>Example</h4>
 				<ul>
@@ -158,7 +165,7 @@ if (!class_exists("Simple301redirects")) {
 		</div>
 		<?php
 		} // end of function options_page
-		
+
 		/**
 		 * expand_redirects function
 		 * utility function to return the current list of redirects as form fields
@@ -174,20 +181,20 @@ if (!class_exists("Simple301redirects")) {
 					$counter++;
 					$row_class = ($counter % 2 === 0) ? 'row_static' : 'row_static alternate';
 					$output .= '
-					
+
 					<tr id="s301r_row_'.$index.'" class="'.$row_class.'">
 						<td class="s301r_request">'.$redirect['request'].'</td>
 						<td>&raquo;</td>
 						<td class="s301r_destination">'.$redirect['destination'].'</td>
 						<td class="s301r-delete"><input type="checkbox" name="301_redirects[delete][]" value="'.$index.'"></td>
 					</tr>
-					
+
 					';
 				}
 			} // end if
 			return $output;
 		}
-		
+
 		/**
 		 * save_redirects function
 		 * save the redirects from the options page to the database
@@ -198,10 +205,19 @@ if (!class_exists("Simple301redirects")) {
 		function save_redirects() {
 			if ( !current_user_can('manage_options') )  { wp_die( 'You do not have sufficient permissions to access this page.' ); }
 			check_admin_referer( 'save_redirects', '_s301r_nonce' );
-			
+
 			// get existing redirects
 			$redirects = get_option( 's301r_redirects' );
 			if ($redirects == '') { $redirects = array(); }
+
+			//insert sitemap data
+			if ( ($_FILES['sitemap']) ) {
+				$urls = $this->process_sitemap($_FILES['sitemap']);
+				foreach ($urls as $url) {
+					$redirects[] = $this->create_redirect($url, '');
+				}
+			}
+
 			$data = $_POST['301_redirects'];
 
 			// delete checked redirect
@@ -212,15 +228,12 @@ if (!class_exists("Simple301redirects")) {
 			}
 
 			// save new redirect
-			if ( trim( $data['request'] ) != '' && trim( $data['destination'] != '' ) ) {
-				$redirects[] = array( 
-					'request' => trim( $data['request'] ),
-					'destination' => trim( $data['destination'] ),
-				);
+			if ( trim( $data['request'] ) != '' ) {
+				$redirects[] = $this->create_redirect($data['request'], $data['destination']);
 			}
 
 			update_option('s301r_redirects', $redirects);
-			
+
 			if (isset($data['wildcard'])) {
 				$settings['wildcard'] = 'true';
 			}
@@ -230,10 +243,43 @@ if (!class_exists("Simple301redirects")) {
 
 			update_option('s301r_settings', $settings);
 		}
-		
+
+		/**
+		* process_sitemap
+		* Read sitemap from a user-uploaded sitemap.xml file and
+		* return the list of redirects processed from the file.
+		* @access private
+		* @param filename
+		* @return array redirect list
+		*/
+		private function process_sitemap($file) {
+			if ( $file['type'] !== 'text/xml') {
+				//create flash for wrong file type		//!!TO DO!!!!!
+				return;
+			}
+			try {
+				$xml = simplexml_load_file($file['tmp_name']);
+			} catch (Exception $e) {
+				//create flash for no XML parser installed or not valid XML
+				return;
+			}
+			$urls = array();
+			foreach ($xml->url as $url) {
+				if ( !empty($url) ) $urls[] = (string) $url->loc;
+			}
+			return $urls;
+		}
+
+		private function create_redirect($request, $destination) {
+			return array(
+				'request' => trim($request),
+				'destination' => trim($destination)
+			);
+		}
+
 		/**
 		 * redirect function
-		 * Read the list of redirects and if the current page 
+		 * Read the list of redirects and if the current page
 		 * is found in the list, send the visitor on her way
 		 * @access public
 		 * @return void
@@ -242,20 +288,20 @@ if (!class_exists("Simple301redirects")) {
 			// this is what the user asked for (strip out home portion, case insensitive)
 			$userrequest = str_ireplace(get_option('home'),'',$this->get_address());
 			$userrequest = rtrim($userrequest,'/');
-			
+
 			$this->maybe_upgrade_db(); // upgrade the storage format if needed @todo: benchmark this, tune for speed
 
 			$redirects = get_option('s301r_redirects');
 			if (!empty($redirects)) {
 				$settings = get_option('s301r_settings');
 				$do_redirect = '';
-				
+
 				// compare user request to each 301 stored in the db
 				foreach ($redirects as $key => $redirect) {
-					// check if we should use regex search 
+					// check if we should use regex search
 					if ($settings['wildcard'] === 'true' && strpos($redirect['request'],'*') !== false) {
 						// wildcard redirect
-						
+
 						// don't allow people to accidentally lock themselves out of admin
 						if ( strpos($userrequest, '/wp-login') !== 0 && strpos($userrequest, '/wp-admin') !== 0 ) {
 							// Make sure it gets all the proper decoding and rtrim action
@@ -273,7 +319,7 @@ if (!class_exists("Simple301redirects")) {
 						// simple comparison redirect
 						$do_redirect = $redirect['destination'];
 					}
-					
+
 					// redirect. the second condition here prevents redirect loops as a result of wildcards.
 					if ($do_redirect !== '' && trim($do_redirect,'/') !== trim($userrequest,'/')) {
 						// check if destination needs the domain prepended
@@ -301,7 +347,7 @@ if (!class_exists("Simple301redirects")) {
 
 			$index = intval( str_replace('s301r_row_', '', $row) );
 			$redirects = get_option( 's301r_redirects' );
-			
+
 			if (is_array( $redirects ) && isset( $redirects[$index] )) { // delete the redirect
 				unset($redirects[$index]);
 				update_option( 's301r_redirects', $redirects );
@@ -310,7 +356,7 @@ if (!class_exists("Simple301redirects")) {
 			}
 			else { echo 'failure'; exit; } // something went wrong
 		}
-		
+
 		/**
 		 * getAddress function
 		 * utility function to get the full address of the current request
@@ -322,7 +368,7 @@ if (!class_exists("Simple301redirects")) {
 			// return the full address
 			return $this->get_protocol().'://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
 		} // end function get_address
-		
+
 		function get_protocol() {
 			// Set the base protocol to http
 			$protocol = 'http';
@@ -330,7 +376,7 @@ if (!class_exists("Simple301redirects")) {
 			if ( isset( $_SERVER["HTTPS"] ) && strtolower( $_SERVER["HTTPS"] ) == "on" ) {
     			$protocol .= "s";
 			}
-			
+
 			return $protocol;
 		} // end function get_protocol
 
@@ -338,7 +384,7 @@ if (!class_exists("Simple301redirects")) {
 			$latest_db_version = 2;
 			$db_version = ( get_option( 's301r_db_version' ) ) ? intval( get_option( 's301r_db_version' ) ) : 1;
 			if ( $latest_db_version === $db_version ) return; // return early, don't slow down the admin
-			
+
 			while ($db_version < $latest_db_version) { // upgrade through each version of the database, in case users jump multiple versions
 				if ( $db_version === 1 ) $this->upgrade_db_v2();
 				// elseif ( $db_version === 2 ) $this->upgrade_db_v3(); // a future version would look like this
@@ -363,7 +409,7 @@ if (!class_exists("Simple301redirects")) {
 
 			if (!empty($v1_redirects)) {
 				update_option( 's301r_archive_data', $v1_redirects ); // save a backup in case something goes wrong during upgrade
-				
+
 				foreach ($v1_redirects as $request => $destination) {
 					$v2_redirects[$counter] = array(
 						'request' => $request,
@@ -378,9 +424,9 @@ if (!class_exists("Simple301redirects")) {
 			// new db version
 			update_option( 's301r_db_version', 2 );
 		} // end function upgrade_db_v2
-		
+
 	} // end class Simple301Redirects
-	
+
 } // end check for existance of class
 
 // instantiate

--- a/wp-simple-301-redirects.php
+++ b/wp-simple-301-redirects.php
@@ -293,7 +293,7 @@ if (!class_exists("Simple301redirects")) {
 
 			// save new redirect
 			if ( trim( $data['request'] ) != '' ) {
-				$redirects[] = $this->create_redirect($data['request'], $data['destination']);
+				array_push( $redirects, $this->create_redirect($data['request'], $data['destination']) );
 			}
 
 			if (isset($data['wildcard'])) {
@@ -345,7 +345,7 @@ if (!class_exists("Simple301redirects")) {
 				$url_str = empty($url_obj->loc) ? '' : (string) $url_obj->loc;
 				if ( $url_str !== '' ) {
 					$redirect = $this->create_redirect($url_str, '');
-					$redirects[] = $redirect;
+					array_push( $redirects, $redirect );
 				}
 			}
 


### PR DESCRIPTION
I made some enhancements to reflect the workflow we use to launch site - feel free to merge or reject it as you see fit.

Basically, you can now add a list of requests by uploading a sitemap, and you can select destinations by choosing from a dropdown list of posts and pages (and custom post types).

All the previous functionality is still there, and there's no difference in how data is stored or how redirects are carried out. I tested out "upgrading" from 1.06 to this and had no problems.