### PR TITLE
Change $userrequest source in redirect()

### DIFF
--- a/wp-simple-301-redirects.php
+++ b/wp-simple-301-redirects.php
@@ -240,7 +240,7 @@ if (!class_exists("Simple301redirects")) {
 		 */
 		function redirect() {
 			// this is what the user asked for (strip out home portion, case insensitive)
-			$userrequest = str_ireplace(get_option('home'),'',$this->get_address());
+			$userrequest = $_SERVER['REQUEST_URI'];
 			$userrequest = rtrim($userrequest,'/');
 			
 			$this->maybe_upgrade_db(); // upgrade the storage format if needed @todo: benchmark this, tune for speed
@@ -310,29 +310,6 @@ if (!class_exists("Simple301redirects")) {
 			}
 			else { echo 'failure'; exit; } // something went wrong
 		}
-		
-		/**
-		 * getAddress function
-		 * utility function to get the full address of the current request
-		 * credit: http://www.phpro.org/examples/Get-Full-URL.html
-		 * @access public
-		 * @return void
-		 */
-		function get_address() {
-			// return the full address
-			return $this->get_protocol().'://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
-		} // end function get_address
-		
-		function get_protocol() {
-			// Set the base protocol to http
-			$protocol = 'http';
-			// check for https
-			if ( isset( $_SERVER["HTTPS"] ) && strtolower( $_SERVER["HTTPS"] ) == "on" ) {
-    			$protocol .= "s";
-			}
-			
-			return $protocol;
-		} // end function get_protocol
 
 		function maybe_upgrade_db() {
 			$latest_db_version = 2;


### PR DESCRIPTION
While testing a site that uses a mixed HTTP/HTTPS setup, I ran into an issue here related to the get_protocol() function. It seems to me that neither get_protocol() nor get_address() are necessary, as PHP provides $_SERVER['REQUEST_URI'], which has already the name of the requested page without hostname or protocol. Please consider merging this change to further simplify this awesome plugin and add support for even more sites (e.g. those with multiple server aliases, etc.)